### PR TITLE
AudioContext is now a singleton

### DIFF
--- a/client-jb/src/components/AllLessons.js
+++ b/client-jb/src/components/AllLessons.js
@@ -19,6 +19,10 @@ const AllLessons = () => {
 
   useEffect(() => {
     const data = JSON.parse(localStorage.getItem("scoreData"));
+    if (data === null) {
+      console.log("No scores data found in local storage");
+      return;
+    }
     const treeData = data.reduce((result, item) => {
       const { level, skill, _id, fname, title } = item;
       result[level] = result[level] || {};

--- a/client-jb/src/components/AudioPlayer.js
+++ b/client-jb/src/components/AudioPlayer.js
@@ -1,4 +1,5 @@
 import React, { useState, useRef } from "react";
+import { getAudioContext, suspendAudioContext, resumeAudioContext } from '../context/audioContext';
 
 const AudioPlayer = () => {
   const [audioBuffer, setAudioBuffer] = useState(null);
@@ -14,8 +15,7 @@ const AudioPlayer = () => {
       reader.onload = function (importedFile) {
         if (file.name.endsWith(".mp3")) {
           // Handle audio file
-          const audioContext = new (window.AudioContext ||
-            window.webkitAudioContext)();
+          const audioContext = getAudioContext();
           audioContext.decodeAudioData(
             importedFile.target.result,
             function (buffer) {
@@ -38,8 +38,7 @@ const AudioPlayer = () => {
 
   const playAudio = () => {
     if (audioBuffer) {
-      const audioContext = new (window.AudioContext ||
-        window.webkitAudioContext)();
+      const audioContext = getAudioContext();
       const source = audioContext.createBufferSource();
       source.buffer = audioBuffer;
       source.connect(audioContext.destination);

--- a/client-jb/src/components/audioStreamer.js
+++ b/client-jb/src/components/audioStreamer.js
@@ -16,45 +16,11 @@ USAGE:
 
 import { makeCrepeScriptNode } from "./pitch/crepeScriptNode.js";
 import Meyda from "meyda"; //https://meyda.js.org
+import { getAudioContext, suspendAudioContext, resumeAudioContext } from '../context/audioContext';
 
 const meyda_buff_fft_length = 1024; // fft length and buf size are the same for Meyda
 
-function createAudioContext() {
-  var AudioContext = window.AudioContext || window.webkitAudioContext;
-  
-  if (!AudioContext) {
-      console.error("AudioContext is not supported in this browser");
-      return null;
-  }
-
-  var audioContext = new AudioContext({
-    latencyHint: "interactive",
-    sampleRate: 22050,
-  });
-
-  // Check if the audio context is in suspended state (autoplay policy)
-  if (audioContext.state === 'suspended') {
-      // Add a click event listener to resume the AudioContext
-      var resumeAudio = function() {
-          audioContext.resume().then(() => {
-              console.log("AudioContext resumed!");
-              document.removeEventListener('click', resumeAudio);
-          });
-      };
-      resumeAudio();
-      // if (window.confirm("Start audio processing?")) {
-      //   console.log("will resume audio"   );
-      //   resumeAudio();
-      // } else {
-      //   console.log("Oh boy, now you've one it!");
-      // }
-  }
-
-  return audioContext;
-}
-
-var audioContext = createAudioContext();
-
+var audioContext = getAudioContext();
 
 
 var mediaRecorder = null;
@@ -95,7 +61,8 @@ var makeAudioStreamer = function (
             console.log("We're now recording stuff :D");
           };
 
-          audioContext.resume();
+          // audioContext.resume();
+          resumeAudioContext();
           const sourceNode = audioContext.createMediaStreamSource(stream);
 
 
@@ -159,7 +126,8 @@ var makeAudioStreamer = function (
     },    
     close_not_save: function (){
       //mediaRecorder.stop();
-      audioContext.suspend();
+      // audioContext.suspend();
+      suspendAudioContext();
     },
     close_maybe_save: function (){
       mediaRecorder.stop();
@@ -175,19 +143,22 @@ var makeAudioStreamer = function (
           const arrayBuffer = await audioBlob.arrayBuffer();
           // Clean
           audioChunks = [];
-          audioContext.suspend();
+          //audioContext.suspend();
+          suspendAudioContext();
           return arrayBuffer;
         } catch (error) {
           console.error('Error converting Blob to ArrayBuffer:', error);
           // Clean
           audioChunks = [];
-          audioContext.suspend();
+          //audioContext.suspend();
+          suspendAudioContext();
           return 0
         }
       }
       
       audioChunks = [];
       audioContext.suspend();
+      suspendAudioContext();  
     },
   };
   

--- a/client-jb/src/context/audioContext.js
+++ b/client-jb/src/context/audioContext.js
@@ -1,0 +1,27 @@
+// src/audioContext.js
+let audioContext;
+
+function createAudioContext() {
+  return new (window.AudioContext || window.webkitAudioContext)({ latencyHint: 'interactive' });
+}
+
+export function getAudioContext() {
+  if (!audioContext) {
+    audioContext = createAudioContext();
+  }
+  return audioContext;
+}
+
+export async function suspendAudioContext() {
+  if (audioContext && audioContext.state !== 'suspended') {
+    await audioContext.suspend();
+  }
+}
+
+export async function resumeAudioContext() {
+  if (!audioContext) {
+    audioContext = createAudioContext();
+  } else if (audioContext.state === 'suspended') {
+    await audioContext.resume();
+  }
+}

--- a/client-jb/src/pages/dashboard/Stats.js
+++ b/client-jb/src/pages/dashboard/Stats.js
@@ -124,6 +124,10 @@ const Stats = () => {
   useEffect(() => {
     // import local data
     const local = JSON.parse(localStorage.getItem("scoreData"));
+    if (local === null) {
+      console.log("No scores data found in local storage");
+      return;
+    }
     // save in state
     setScoresData(local);
     // Count the total number of stars per level, and save


### PR DESCRIPTION
The AudioContext getting, suspending, resuming, is now all done through methods that are imported in files that use them:
import { getAudioContext, suspendAudioContext, resumeAudioContext } from '../context/audioContext';

This way, the whole app uses only a single AudioContext, created only on the first call to getAudioContext. 

Test this by playing /stopping recordings, and by using the 'back' button while a song is playing.
In both cases, the sound should cleanly stop as you would expect (no crashing, no continuous play if you move to a different page). 

=====================

I also tweaked Stats.js to write a message to the console if there are now scores in local storage, rather than produce a "Something Went Wrong" page on the app.  Test this by deleting scores in local storage, logging out, and logging back in. 