### PR TITLE
mostly updated some movement-titles in xml files so that no two have …

### DIFF
--- a/client-jb/public/xmlScores/violin/V_005_Cuerdas_Al_Aire_2_Suelta_A.xml
+++ b/client-jb/public/xmlScores/violin/V_005_Cuerdas_Al_Aire_2_Suelta_A.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.1">
-  <movement-title>Autumn walk</movement-title>
+  <movement-title>Autumn walk 2</movement-title>
   <identification>
     <rights>©</rights>
     <encoding>

--- a/client-jb/public/xmlScores/violin/V_006_Cuerdas_Al_Aire_2_Suelta_D.xml
+++ b/client-jb/public/xmlScores/violin/V_006_Cuerdas_Al_Aire_2_Suelta_D.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.1">
-  <movement-title>Little Puppy</movement-title>
+  <movement-title>Little Puppy 2</movement-title>
   <identification>
     <rights>©</rights>
     <encoding>

--- a/client-jb/public/xmlScores/violin/V_007_Cuerdas_Al_Aire_2_Suelta_G.xml
+++ b/client-jb/public/xmlScores/violin/V_007_Cuerdas_Al_Aire_2_Suelta_G.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.1">
-  <movement-title>The sea</movement-title>
+  <movement-title>The sea 2</movement-title>
   <identification>
     <rights>©</rights>
     <encoding>

--- a/client-jb/public/xmlScores/violin/V_008_Cuerdas_Al_Aire_2_Suelta_E.xml
+++ b/client-jb/public/xmlScores/violin/V_008_Cuerdas_Al_Aire_2_Suelta_E.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.1">
-  <movement-title>Surprise Party</movement-title>
+  <movement-title>Surprise Party 2</movement-title>
   <identification>
     <rights>©</rights>
     <encoding>

--- a/client-jb/public/xmlScores/violin/V_043_Segundo_Dedo_Ejercicios_1.xml
+++ b/client-jb/public/xmlScores/violin/V_043_Segundo_Dedo_Ejercicios_1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.1">
-  <movement-title>Ejercicios</movement-title>
+  <movement-title>Ejercicios 1</movement-title>
   <identification>
     <rights>©</rights>
     <encoding>

--- a/client-jb/public/xmlScores/violin/V_044_Segundo_Dedo_Ejercicios_2.xml
+++ b/client-jb/public/xmlScores/violin/V_044_Segundo_Dedo_Ejercicios_2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.1">
-  <movement-title>Ejercicios</movement-title>
+  <movement-title>Ejercicios 2</movement-title>
   <identification>
     <rights>©</rights>
     <encoding>

--- a/client-jb/src/components/audioStreamer.js
+++ b/client-jb/src/components/audioStreamer.js
@@ -81,15 +81,19 @@ var makeAudioStreamer = function (
         }
       };
 
-      mediaRecorder.onstop = () => {
-        console.log('----------MediaRecorder stopped');
-        const audioBlob = new Blob(audioChunks, { type: 'audio/wav' });
-        const audioUrl = URL.createObjectURL(audioBlob);
-        const audio = document.getElementById('audioPlayback');
-        audio.src = audioUrl;
-        audioChunks = [];
+      // mediaRecorder.onstop = () => {
+      //   console.log('----------MediaRecorder stopped');
+      //   const audioBlob = new Blob(audioChunks, { type: 'audio/wav' });
+      //   const audioUrl = URL.createObjectURL(audioBlob);
+      //   const audio = document.getElementById('audioPlayback');
+      //   if (! audio) {
+      //     console.log('No audio element to play back - Should the audio save dialog box return a file name first, or what ?????');
+      //   } else {
+      //     audio.src = audioUrl;
+      //   }
+      //   audioChunks = [];
 
-      };
+      // };
 
 
 


### PR DESCRIPTION
…the same name on our Lessons display. Also commented out a useless stop() method in audioStreamer.

1) Not much to test - check Lessons lists, and see that there are no duplicate display names for pieces. 

2) The audioStreamer change can be checked by seeing that the "hot mic" indicator still turns off as it should when you leave pages that use the mic. 