### PR TITLE
Logout user whenever JWT token is removed from local storage or expires

### DIFF
--- a/client-jb/src/App.js
+++ b/client-jb/src/App.js
@@ -10,7 +10,8 @@ import {
 
 import { Profile, Stats, SharedLayout } from "./pages/dashboard";
 
-import React from "react";
+import React, { useEffect } from "react";
+import { useAppContext } from "./context/appContext";
 
 import AllLessons from "./components/AllLessons";
 import ProgressPlayFile from "./components/ProgressPlayFile";
@@ -32,83 +33,35 @@ import Apitesting from "./components/apitesting";
 import Error from "./components/Error";
 
 function App() {
-  //  const { startTimer, resetTimer} = useTimer();
-  // useEffect(() => {
-  //   const handleVisibilityChange = () => {
-  //     if (document.hidden) {
-  //       // User has navigated away from the tab, or the tab is now in the background
-  //       console.log('User has left the app - resetting session timer.');
-  //       resetTimer();
-  //     } else {
-  //       // User has returned to the app
-  //       console.log('User has returned to the app - starting session timer.');
-  //       startTimer();
-  //     }
-  //   };
-  //   document.addEventListener('visibilitychange', handleVisibilityChange);
-  //   return () => {
-  //     document.removeEventListener('visibilitychange', handleVisibilityChange);
-  //   };
-  // }, []);
+  const { logoutUser } = useAppContext();
 
-  // useEffect(() => {
-  //   console.log('App loaded or user returned to the app - starting session timer.');
-  //   startTimer();
-  // }, []);
+  // Logout user whenever JWT token is missing
+  useEffect(() => {
+    const checkTokenAndLogout = () => {
+      const token = localStorage.getItem("token");
+      if (!token) {
+        logoutUser();
+      }
+    };
 
-  // useEffect(() => {
-  //   const handleTabClose = (event) => {
-  //     // Perform actions like saving the session state
-  //     console.log('User is trying to leave the app resetting session timer.');
-  //     resetTimer();
-  //     // For some browsers, you must return a string that will be shown to the user in a confirmation dialog
-  //     event.preventDefault();
-  //     event.returnValue = '';
-  //   };
-  //   window.addEventListener('beforeunload', handleTabClose);
-  //   return () => {
-  //     window.removeEventListener('beforeunload', handleTabClose);
-  //   };
-  // }, []);
+    // Call checkTokenAndLogout on component mount
+    checkTokenAndLogout();
 
-  //  const { startTimer, resetTimer} = useTimer();
-  // useEffect(() => {
-  //   const handleVisibilityChange = () => {
-  //     if (document.hidden) {
-  //       // User has navigated away from the tab, or the tab is now in the background
-  //       console.log('User has left the app - resetting session timer.');
-  //       resetTimer();
-  //     } else {
-  //       // User has returned to the app
-  //       console.log('User has returned to the app - starting session timer.');
-  //       startTimer();
-  //     }
-  //   };
-  //   document.addEventListener('visibilitychange', handleVisibilityChange);
-  //   return () => {
-  //     document.removeEventListener('visibilitychange', handleVisibilityChange);
-  //   };
-  // }, []);
+    // Event listener for storage changes
+    const handleStorageChange = (event) => {
+      if (event.key === "token" && !event.newValue) {
+        logoutUser();
+      }
+    };
 
-  // useEffect(() => {
-  //   console.log('App loaded or user returned to the app - starting session timer.');
-  //   startTimer();
-  // }, []);
+    // Add event listener to window object
+    window.addEventListener("storage", handleStorageChange);
 
-  // useEffect(() => {
-  //   const handleTabClose = (event) => {
-  //     // Perform actions like saving the session state
-  //     console.log('User is trying to leave the app resetting session timer.');
-  //     resetTimer();
-  //     // For some browsers, you must return a string that will be shown to the user in a confirmation dialog
-  //     event.preventDefault();
-  //     event.returnValue = '';
-  //   };
-  //   window.addEventListener('beforeunload', handleTabClose);
-  //   return () => {
-  //     window.removeEventListener('beforeunload', handleTabClose);
-  //   };
-  // }, []);
+    // Cleanup function to remove the event listener
+    return () => {
+      window.removeEventListener("storage", handleStorageChange);
+    };
+  }, [logoutUser]);
 
   return (
     <div>

--- a/middleware-jb/authenticateUser.js
+++ b/middleware-jb/authenticateUser.js
@@ -1,3 +1,7 @@
+import jwt from "jsonwebtoken";
+import { UnAuthenticatedError } from "../errors/index.js";
+import { logout } from "../controllers/authController.js";
+
 /**
  * Middleware function to authenticate user using JWT token.
  * @param {Object} req - Express request object.
@@ -5,13 +9,8 @@
  * @param {Function} next - Express next middleware function.
  * @throws {UnAuthenticatedError} If authentication fails.
  */
-import jwt from "jsonwebtoken";
-import { UnAuthenticatedError } from "../errors/index.js";
-
 const authenticateUser = async (req, res, next) => {
-  //console.log(`In authenticateUser, req.headers is ${JSON.stringify(req.headers)}`)
   const authHeader = req.headers.authorization;
-  //console.log("authHeader", authHeader);
   console.log("Authenticating...");
   if (!authHeader || !authHeader.startsWith("Bearer")) {
     throw new UnAuthenticatedError("Authentication invalid");
@@ -23,8 +22,9 @@ const authenticateUser = async (req, res, next) => {
     req.user = { userId: payload.userId };
     next();
   } catch (err) {
+    logout(req, res);
     throw new UnAuthenticatedError("Authentication invalid");
   }
 };
 
-export default authenticateUser;
+export { authenticateUser };

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -1,9 +1,14 @@
 import express from "express";
 const router = express.Router();
-import { register, login, updateUser, getProfileData } from "../controllers/authController.js";
-import authenticateUser from "../middleware-jb/authenticateUser.js";
+import {
+  register,
+  login,
+  updateUser,
+  getProfileData,
+} from "../controllers/authController.js";
+import { authenticateUser } from "../middleware-jb/authenticateUser.js";
 
-import bodyParser from 'body-parser';
+import bodyParser from "body-parser";
 // Middleware setup for parsing form data
 const formParser = bodyParser.urlencoded({ extended: false });
 

--- a/routes/profileRoutes.js
+++ b/routes/profileRoutes.js
@@ -1,15 +1,21 @@
-import express from 'express';
-import { changePassword, updateProfileData } from '../controllers/profileController.js';
-import authenticateUser from "../middleware-jb/authenticateUser.js";
+import express from "express";
+import {
+  changePassword,
+  updateProfileData,
+} from "../controllers/profileController.js";
+import { authenticateUser } from "../middleware-jb/authenticateUser.js";
 
-import bodyParser from 'body-parser';
+import bodyParser from "body-parser";
 // Middleware setup for parsing form data
 const formParser = bodyParser.urlencoded({ extended: false });
 
 const router = express.Router();
 
-router.route("/changePassword").post(authenticateUser, formParser, changePassword);
-router.route("/updateProfileData").post(authenticateUser, formParser, updateProfileData);
-
+router
+  .route("/changePassword")
+  .post(authenticateUser, formParser, changePassword);
+router
+  .route("/updateProfileData")
+  .post(authenticateUser, formParser, updateProfileData);
 
 export default router;

--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
 import express from "express";
 import dotenv from "dotenv";
-import bodyParser from 'body-parser';
+import bodyParser from "body-parser";
 
 dotenv.config();
 import "express-async-errors"; // this is a package that allows us to use async await in express
@@ -20,7 +20,7 @@ import profileRouter from "./routes/profileRoutes.js";
 // middleware
 import notFoundMiddleWare from "./middleware-jb/not-found.js";
 import errorHandlerMiddleWare from "./middleware-jb/error-handler.js"; // best practice to import it at the last
-import authenticateUser from "./middleware-jb/authenticateUser.js";
+import { authenticateUser } from "./middleware-jb/authenticateUser.js";
 
 import { dirname } from "path";
 import { fileURLToPath } from "url";
@@ -28,14 +28,13 @@ import path from "path";
 
 const app = express();
 
-app.use(express.json({ limit: '16mb' })); // For JSON payloads
-app.use(express.urlencoded({ limit: '16mb', extended: true })); // For URL-encoded data
+app.use(express.json({ limit: "16mb" })); // For JSON payloads
+app.use(express.urlencoded({ limit: "16mb", extended: true })); // For URL-encoded data
 
 // Middleware to parse application/x-www-form-urlencoded
 app.use(bodyParser.urlencoded({ extended: false }));
 // Middleware to parse application/json
 app.use(bodyParser.json());
-
 
 if (process.env.NODE_ENV !== "production") {
   app.use(morgan("dev")); // morgan is a middleware that allows us to log the requests in the console


### PR DESCRIPTION
**DESCRIPTION**
The JWT token is an important marker used to authorize users on SkyNote. If the JWT token is removed from local storage or expired, we must log the user out. This ensures the user is re-authenticated when they log back in. 

**FILES CHANGED**
- Added useEffect handler to main App component to listen to current window local storage and logout user if the JWT token is ever removed (App.js)
- Modified authenticateUser.js middleware to logout user if the JWT token is not verified (authenticateUser.js)
- Modified export of authenticateUser.js functions to handle potential multi-function exports in the future (authenticateUser.js, server.js, profileRoutes.js, authRoutes.js)

**TESTING**
- [x] Make sure you are logged into Skynote
- [x] Open up the inspect panel
- [x] Delete the entire JWT token local storage variable
- [x] Observe being logged out
- [x] Log back in
- [x] Delete only the name of the JWT token local storage variable (should be "token")
- [x] Observe being logged out
- [x] Log back in
- [x] Delete only the value of the JWT token local storage variable
- [x] Observe being logged out

Testing should be complete :) 