### PR TITLE
Fixing up some more score names.

### DIFF
--- a/client-jb/public/xmlScores/violin/V_001_Cuerdas_Al_Aire_1_Suelta_A.xml
+++ b/client-jb/public/xmlScores/violin/V_001_Cuerdas_Al_Aire_1_Suelta_A.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.1">
-  <movement-title>111Autumn walk</movement-title>
+  <movement-title>Autumn walk</movement-title>
   <identification>
     <rights>©</rights>
     <encoding>

--- a/client-jb/public/xmlScores/violin/V_002_Cuerdas_Al_Aire_1_Suelta_D.xml
+++ b/client-jb/public/xmlScores/violin/V_002_Cuerdas_Al_Aire_1_Suelta_D.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.1">
-  <movement-title>Little Puppy</movement-title>
+  <movement-title>Little Puppy 1</movement-title>
   <identification>
     <rights>©</rights>
     <encoding>
@@ -58,7 +58,7 @@
   </defaults>
   <credit page="1">
     <credit-type>title</credit-type>
-    <credit-words default-x="632" default-y="1472" font-size="24" justify="center" valign="top">Little Puppy</credit-words>
+    <credit-words default-x="632" default-y="1472" font-size="24" justify="center" valign="top">Little Puppy 1</credit-words>
   </credit>
   <credit page="1">
     <credit-type>rights</credit-type>

--- a/client-jb/public/xmlScores/violin/V_017_Cambio_Cuerdas_1_AD.xml
+++ b/client-jb/public/xmlScores/violin/V_017_Cambio_Cuerdas_1_AD.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.1">
-  <movement-title>Cat's Boogie</movement-title>
+  <movement-title>Cat's Boogie 1</movement-title>
   <identification>
     <rights>©</rights>
     <encoding>
@@ -58,7 +58,7 @@
   </defaults>
   <credit page="1">
     <credit-type>title</credit-type>
-    <credit-words default-x="632" default-y="1475" font-size="24" justify="center" valign="top">Cat's Boogie</credit-words>
+    <credit-words default-x="632" default-y="1475" font-size="24" justify="center" valign="top">Cat's Boogie 1</credit-words>
   </credit>
   <credit page="1">
     <credit-type>rights</credit-type>

--- a/client-jb/public/xmlScores/violin/V_018_Cambio_Cuerdas_1_AE.xml
+++ b/client-jb/public/xmlScores/violin/V_018_Cambio_Cuerdas_1_AE.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.1">
-  <movement-title>The playground</movement-title>
+  <movement-title>The playground 1</movement-title>
   <identification>
     <rights>©</rights>
     <encoding>
@@ -58,7 +58,7 @@
   </defaults>
   <credit page="1">
     <credit-type>title</credit-type>
-    <credit-words default-x="631" default-y="1475" font-size="24" justify="center" valign="top">The playground</credit-words>
+    <credit-words default-x="631" default-y="1475" font-size="24" justify="center" valign="top">The playground 1</credit-words>
   </credit>
   <credit page="1">
     <credit-type>rights</credit-type>

--- a/client-jb/public/xmlScores/violin/V_019_Cambio_Cuerdas_1_DG.xml
+++ b/client-jb/public/xmlScores/violin/V_019_Cambio_Cuerdas_1_DG.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.1">
-  <movement-title>Little dance</movement-title>
+  <movement-title>Little dance 1</movement-title>
   <identification>
     <rights>©</rights>
     <encoding>
@@ -58,7 +58,7 @@
   </defaults>
   <credit page="1">
     <credit-type>title</credit-type>
-    <credit-words default-x="632" default-y="1475" font-size="24" justify="center" valign="top">Little dance</credit-words>
+    <credit-words default-x="632" default-y="1475" font-size="24" justify="center" valign="top">Little dance1 </credit-words>
   </credit>
   <credit page="1">
     <credit-type>rights</credit-type>

--- a/client-jb/public/xmlScores/violin/V_020_Cambio_Cuerdas_1_DA.xml
+++ b/client-jb/public/xmlScores/violin/V_020_Cambio_Cuerdas_1_DA.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.1">
-  <movement-title>The ship is sailing</movement-title>
+  <movement-title>The ship is sailing 1</movement-title>
   <identification>
     <rights>©</rights>
     <encoding>
@@ -58,7 +58,7 @@
   </defaults>
   <credit page="1">
     <credit-type>title</credit-type>
-    <credit-words default-x="632" default-y="1475" font-size="24" justify="center" valign="top">The ship is sailing</credit-words>
+    <credit-words default-x="632" default-y="1475" font-size="24" justify="center" valign="top">The ship is sailing 1</credit-words>
   </credit>
   <credit page="1">
     <credit-type>rights</credit-type>

--- a/client-jb/public/xmlScores/violin/V_021_Cambio_Cuerdas_1-a_AD.xml
+++ b/client-jb/public/xmlScores/violin/V_021_Cambio_Cuerdas_1-a_AD.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.1">
-  <movement-title>Cat's Boogie</movement-title>
+  <movement-title>Cat's Boogie 2</movement-title>
   <identification>
     <rights>©</rights>
     <encoding>
@@ -58,7 +58,7 @@
   </defaults>
   <credit page="1">
     <credit-type>title</credit-type>
-    <credit-words default-x="632" default-y="1475" font-size="24" justify="center" valign="top">Cat's Boogie</credit-words>
+    <credit-words default-x="632" default-y="1475" font-size="24" justify="center" valign="top">Cat's Boogie 2</credit-words>
   </credit>
   <credit page="1">
     <credit-type>rights</credit-type>

--- a/client-jb/public/xmlScores/violin/V_022_Cambio_Cuerdas_1-a_AE.xml
+++ b/client-jb/public/xmlScores/violin/V_022_Cambio_Cuerdas_1-a_AE.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.1">
-  <movement-title>The playground</movement-title>
+  <movement-title>The playground 2</movement-title>
   <identification>
     <rights>©</rights>
     <encoding>
@@ -58,7 +58,7 @@
   </defaults>
   <credit page="1">
     <credit-type>title</credit-type>
-    <credit-words default-x="632" default-y="1475" font-size="24" justify="center" valign="top">The playground</credit-words>
+    <credit-words default-x="632" default-y="1475" font-size="24" justify="center" valign="top">The playground 2</credit-words>
   </credit>
   <credit page="1">
     <credit-type>rights</credit-type>

--- a/client-jb/public/xmlScores/violin/V_023_Cambio_Cuerdas_1-a_DG.xml
+++ b/client-jb/public/xmlScores/violin/V_023_Cambio_Cuerdas_1-a_DG.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.1">
-  <movement-title>Little dance</movement-title>
+  <movement-title>Little dance 2</movement-title>
   <identification>
     <rights>©</rights>
     <encoding>
@@ -58,7 +58,7 @@
   </defaults>
   <credit page="1">
     <credit-type>title</credit-type>
-    <credit-words default-x="632" default-y="1475" font-size="24" justify="center" valign="top">Little dance</credit-words>
+    <credit-words default-x="632" default-y="1475" font-size="24" justify="center" valign="top">Little dance2</credit-words>
   </credit>
   <credit page="1">
     <credit-type>rights</credit-type>

--- a/client-jb/public/xmlScores/violin/V_024_Cambio_Cuerdas_1-a_DA.xml
+++ b/client-jb/public/xmlScores/violin/V_024_Cambio_Cuerdas_1-a_DA.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.1">
-  <movement-title>The ship is sailing</movement-title>
+  <movement-title>The ship is sailing 2</movement-title>
   <identification>
     <rights>©</rights>
     <encoding>
@@ -58,7 +58,7 @@
   </defaults>
   <credit page="1">
     <credit-type>title</credit-type>
-    <credit-words default-x="632" default-y="1475" font-size="24" justify="center" valign="top">The ship is sailing</credit-words>
+    <credit-words default-x="632" default-y="1475" font-size="24" justify="center" valign="top">The ship is sailing 2</credit-words>
   </credit>
   <credit page="1">
     <credit-type>rights</credit-type>


### PR DESCRIPTION
The intent was to fix the "Something went wrong" page that comes up when clicking *some* scores. I am not able to reproduce that right now and it *might* be because I've cleared local storage and my browser cache.

The other thing that should be fixed now is the duplication of names for scores that were actually a bid different ( see Level I -> 2 Strings Changing). 

So to test this pull request. 

1) See that there are no weird or duplicate file names anywhere in the lessons score name - in particular Level I -> 2 Strings Changing 

2) See that we don't get "something went wrong" anywhere (which I suspect was a mismatch between a name used to record and the new name of the score). 