### PR TITLE
ENG-54 Ensure user recording doesn't save when system crashes

### DIFF
--- a/client-jb/src/components/ProgressPlayFile.js
+++ b/client-jb/src/components/ProgressPlayFile.js
@@ -457,8 +457,45 @@ const ProgressPlayFile = () => {
     }
   }, [pitchValue, dynamicValue]);
 
+  // Delete recording if system crashes or user leaves page while recording
+  useEffect(() => {
+    const handleBeforeUnload = (event) => {
+      // Ensure recording is not saved and audioStreamer is properly cleaned up
+      if (isRecording) {
+        audioStreamer.save_or_not("delete");
+        stopRecordingAudio(playbackRef.current);
+      }
+      // Cancel the event as stated by the standard
+      event.preventDefault();
+      // Chrome requires returnValue to be set
+      event.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+      if (isMicrophoneActive()) {
+        stopMicrophone();
+      }
+      audioStreamer && audioStreamer.close();
+    };
+  }, []);
+
+  // TEMPORARY: Simulate a crash scenario (for demonstration purposes)
+  const [simulateCrash, setSimulateCrash] = useState(false);
+  // useEffect to simulate crash
+  useEffect(() => {
+    if (simulateCrash) {
+      // Simulate a crash scenario (for demonstration purposes)
+      throw new Error("Simulated crash for testing");
+    }
+  }, [simulateCrash]);
+
   return (
     <div className="flex flex-col min-h-screen justify-between">
+      <button onClick={() => setSimulateCrash(true)}>Simulate Crash</button>
+
       <div>
         <OpenSheetMusicDisplay
           file={`${folderBasePath}/${params.files}.xml`}

--- a/client-jb/src/components/ProgressPlayFile.js
+++ b/client-jb/src/components/ProgressPlayFile.js
@@ -482,20 +482,8 @@ const ProgressPlayFile = () => {
     };
   }, []);
 
-  // TEMPORARY: Simulate a crash scenario (for demonstration purposes)
-  const [simulateCrash, setSimulateCrash] = useState(false);
-  // useEffect to simulate crash
-  useEffect(() => {
-    if (simulateCrash) {
-      // Simulate a crash scenario (for demonstration purposes)
-      throw new Error("Simulated crash for testing");
-    }
-  }, [simulateCrash]);
-
   return (
     <div className="flex flex-col min-h-screen justify-between">
-      <button onClick={() => setSimulateCrash(true)}>Simulate Crash</button>
-
       <div>
         <OpenSheetMusicDisplay
           file={`${folderBasePath}/${params.files}.xml`}


### PR DESCRIPTION
**CODE**
- Modify ProgressPlayFile to ensure that recordings do not save when the system crashes

**TESTING**
- [x] Select any lesson from the dashboard page
- [x] Observe TEMPORARY simulate crash button :D 
- [x] Record a lesson and while recording click the button to simulate a crash
- [x] Navigate to dashboard and view all recordings for that lesson
- [x] Observe that recording is not saved
- [x] Make another recording with the same lesson and this time save the recording
- [x] Navigate to dashboard and view that recording for that lesson
- [x] Listen to the recording

Testing is complete!