### PR TITLE
ENG-59-a - Impede user interaction with OSMD component when recording or playing back audio

### DIFF
--- a/client-jb/src/components/ProgressPlayFile.js
+++ b/client-jb/src/components/ProgressPlayFile.js
@@ -390,13 +390,14 @@ const ProgressPlayFile = () => {
 
   // Toggle the recording state
   const handleToggleRecord = () => {
-    setIsPlaying((prevIsRecording) => !prevIsRecording);
+    setIsRecording((prevIsRecording) => !prevIsRecording);
   };
 
   // Reset and stop all recording and MIDI playback
   const handleToggleReset = () => {
     const playbackManager = playbackRef.current;
     resetAudio(playbackManager);
+    playbackManager.setPlaybackStart(0);
 
     setIsListening(false);
     setIsPlaying(false);
@@ -525,6 +526,7 @@ const ProgressPlayFile = () => {
     const playbackManager = playbackRef.current;
     if (playbackManager) {
       if (isRecording) {
+        playbackManager.setPlaybackStart(0);
         recordAudio(playbackManager);
       } else {
         stopRecordingAudio(playbackManager);
@@ -637,7 +639,7 @@ const ProgressPlayFile = () => {
   return (
     <HotKeys keyMap={keyMap} handlers={handlers}>
       <div className="flex flex-col min-h-screen justify-between">
-        <div>
+        <div className="relative">
           <OpenSheetMusicDisplay
             file={`${folderBasePath}/${params.files}.xml`}
             autoResize={true}
@@ -663,6 +665,9 @@ const ProgressPlayFile = () => {
             canDownload={canDownload}
             visual={"no"}
           />
+          {(isRecording || isPlaying) && (
+            <div className="absolute top-0 left-0 w-full h-full bg-transparent z-20 pointer-events-auto"></div>
+          )}
         </div>
 
         <div className="flex justify-center mb-32">

--- a/client-jb/src/components/ProgressPlayFileVisual.js
+++ b/client-jb/src/components/ProgressPlayFileVisual.js
@@ -345,7 +345,7 @@ const ProgressPlayFileVisual = () => {
   return (
     <HotKeys keyMap={keyMap} handlers={handlers}>
       <div className="flex flex-col min-h-screen justify-between">
-        <div>
+        <div className="relative">
           <OpenSheetMusicDisplay
             file={`${folderBasePath}/${params.files}.xml`}
             autoResize={true}
@@ -370,6 +370,7 @@ const ProgressPlayFileVisual = () => {
             visual={"yes"}
             visualJSON={json}
           />
+          <div className="absolute top-0 left-0 w-full h-full bg-transparent z-20 pointer-events-auto"></div>
         </div>
 
         <div className="flex justify-center mb-32">


### PR DESCRIPTION
**SUMMARY**
- Removed cursor interaction in playback mode (i.e. clicking the OSMD component notes) to avoid synchronization issues with OSMD timing source and audio context

**CODE**
- Added a sibling component to the OSMD component in ProgressPlayFileVisual that disables all cursor interactions, so user cannot click a note to change the playback start position (ProgressPlayFileVisual.js)

**TESTING**
- [x] Open any score
- [x] Practice the score
- [x] Try clicking on the score notes or lines while practicing is happening
- [x] Observe that you cannot make any changes to the cursor position
- [x] Go to record mode
- [x] Set the starting position of the cursor in the middle of the score
- [x] Record the score
- [x] Observe that the starting position before recording resets to the beginning of the score
- [x] Reset the score
- [x] Record the score again
- [x] Try clicking on the score notes or lines while recording is happening
- [x] Observe that you cannot make any changes to the cursor position
- [x] Go to your recording
- [x] Try clicking on the score to trigger a note
- [x] Observe that you cannot click or trigger a note
- [x] Play the recording
- [x] Try clicking on the score to trigger a note
- [x] Observe that clicking on a note does not work and playback is not disturbed

Testing is complete :) 