### PR TITLE
ENG-95: Fix transpose when set back to 0

### DIFF
--- a/client-jb/src/components/OpenSheetMusicDisplay.js
+++ b/client-jb/src/components/OpenSheetMusicDisplay.js
@@ -298,12 +298,16 @@ const OpenSheetMusicDisplay = (props) => {
 
   const updateTranspose = (newTranspose) => {
     if (newTranspose !== undefined && newTranspose) {
+      // if (newTranspose === '0') {
+      //   setupOsmd();
+      // } else {
       osmd.current.Sheet.Transpose = parseInt(newTranspose);
       osmd.current.updateGraphic();
       if (osmd.current.IsReadyToRender()) osmd.current.render();
       if (osmd.current.graphic)
         [osmd.current.IDdict, osmd.current.IDInvDict] =
           generateNoteIDsAssociation(osmd.current);
+      // }
     }
   };
 
@@ -388,8 +392,7 @@ const OpenSheetMusicDisplay = (props) => {
             undefined
         ) {
           notePitch =
-            osmd.current.cursor.NotesUnderCursor()[0].TransposedPitch !==
-            undefined
+            parseInt(props.transpose) !== 0
               ? osmd.current.cursor.NotesUnderCursor()[0].TransposedPitch
                   .frequency
               : osmd.current.cursor.NotesUnderCursor()[0].Pitch.frequency;


### PR DESCRIPTION
***CODE***
- Solve transpose bug where pitch tracking does not work after transpose is set back to 0

***TESTING***
- [ ] Choose any score you want to test with
- [ ] Practice the score normally without transpose
- [ ] Observe correct pitch tracking note colors and lines
- [ ] Practice the score transposed 
- [ ] Observe correct pitch tracking note colors and lines
- [ ] Practice the score with transposition set back to 0
- [ ] Observe correct pitch tracking note colors and lines

Testing complete!